### PR TITLE
install: Update if installed version != configured version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,11 @@ mattermost_enterprise: false
 mattermost_teams: []
 mattermost_channels: []
 mattermost_admins: []
+mattermost_preserve_on_update:
+  - config
+  - logs
+  - bin/plugins
+  - bin/data
 # MATTERMOST config.json SETTINGS
 
 mattermost_Service_SiteURL: ""

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,8 +3,6 @@
   copy:
     src: "{{ inventory_hostname }}/mattermost_licence"
     dest: "{{ mattermost_Service_LicenseFileLocation }}"
-    owner: "{{ mattermost_user }}"
-    group: "{{ mattermost_user }}"
     mode: 0600       
   when: mattermost_enterprise
 
@@ -12,35 +10,8 @@
   template:
     src: mattermost-config.json.j2
     dest: /opt/mattermost/config/config.json
-    owner: "{{ mattermost_user }}"
-    group: "{{ mattermost_user }}"
     mode: 0644
 
-- name: Change Mattermost directory permissions
-  file:
-    path: /opt/mattermost
-    state: directory
-    owner: "{{ mattermost_user }}"
-    group: "{{ mattermost_user }}"
-    recurse: yes
-
-- name: Place Mattermost licence file
-  copy:
-    src: "{{ inventory_hostname }}/mattermost_licence"
-    dest: "{{ mattermost_Service_LicenseFileLocation }}"
-    owner: "{{ mattermost_user }}"
-    group: "{{ mattermost_user }}"
-    mode: 0600       
-  when: mattermost_enterprise
-
-- name: Apply Mattermost config.json template
-  template:
-    src: mattermost-config.json.j2
-    dest: /opt/mattermost/config/config.json
-    owner: "{{ mattermost_user }}"
-    group: "{{ mattermost_user }}"
-    mode: 0644
-  
 - name: Change Mattermost directory permissions
   file:
     path: /opt/mattermost

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,11 @@
 ---
+
+- name: Create user to run Mattermost service
+  user:
+    name: "{{ mattermost_user }}"
+    system: yes
+    createhome: no
+
 - name: Place Mattermost licence file
   copy:
     src: "{{ inventory_hostname }}/mattermost_licence"

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -1,0 +1,16 @@
+---
+# Deploys /opt/mattermost-updated/mattermost to /opt/mattermost
+# Attention: This doesn't check if the (valid) updated version exists
+
+- name: Remove the old mattermost folder
+  file:
+    path: /opt/mattermost
+    state: absent
+
+- name: Move the displaced mattermost folder into its place
+  command: mv /opt/mattermost-updated/mattermost /opt/mattermost
+
+- name: Remove the mattermost-updated folder
+  file:
+    path: /opt/mattermost-updated
+    state: absent

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,46 +1,25 @@
 ---
-- name: 'Download binary from https://releases.mattermost.com'
-  get_url: 
-    url: 'https://releases.mattermost.com/{{ mattermost_version }}/mattermost-team-{{ mattermost_version }}-linux-amd64.tar.gz'
-    dest: "{{ global_cache_dir | mandatory }}/"
-  when: not mattermost_enterprise
-  become: false
-  delegate_to: localhost
 
-- name: 'Download enterprise version binary from https://releases.mattermost.com'
-  get_url: 
-    url: 'https://releases.mattermost.com/{{ mattermost_version }}/mattermost-{{ mattermost_version }}-linux-amd64.tar.gz'
-    dest: "{{ global_cache_dir | mandatory }}/"
-  when: mattermost_enterprise
-  become: false
-  delegate_to: localhost
+- name: Check if a previous update wasn't deployed
+  stat:
+    path: /opt/mattermost-updated/mattermost
+  register: mattermost_updated_stat
 
-- name: Unpack Mattermost archive
-  unarchive: 
-    src: "{{ global_cache_dir }}/mattermost-team-{{ mattermost_version }}-linux-amd64.tar.gz"
-    dest: /opt/
-  args:
-    creates: /opt/mattermost/bin/platform
-  when: not mattermost_enterprise
+- import_tasks: deploy.yml
+  when: mattermost_updated_stat.stat.exists
 
-- name: Unpack Mattermost enterprise archive
-  unarchive: 
-    src: "{{ global_cache_dir }}/mattermost-{{ mattermost_version }}-linux-amd64.tar.gz"
-    dest: /opt/
-  args:
-    creates: /opt/mattermost/bin/platform
-  when: mattermost_enterprise
+- name: Check if a previous mattermost version exists
+  stat:
+    path: /opt/mattermost/version
+  register: previous_mattermost_version_stat
 
-- name: Create user to run Mattermost service
-  user: 
-    name: "{{ mattermost_user }}"
-    system: yes
-    createhome: no 
+- name: Get the previous mattermost version
+  slurp:
+    src: /opt/mattermost/version
+  register: previous_mattermost_version
+  when: previous_mattermost_version_stat.stat.exists
 
-- name: Create version file
-  copy:
-    content: "{{ mattermost_version }}"
-    dest: /opt/mattermost/version
-    force: yes
-    owner: "{{ mattermost_user }}"
-    mode: 0644
+- block:
+  - import_tasks: update.yml
+  - import_tasks: deploy.yml
+  when: not previous_mattermost_version_stat.stat.exists or previous_mattermost_version['content'] | b64decode != mattermost_version

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -36,3 +36,11 @@
     name: "{{ mattermost_user }}"
     system: yes
     createhome: no 
+
+- name: Create version file
+  copy:
+    content: "{{ mattermost_version }}"
+    dest: /opt/mattermost/version
+    force: yes
+    owner: "{{ mattermost_user }}"
+    mode: 0644

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -1,0 +1,75 @@
+---
+# Creates a folder /opt/mattermost-updated/mattermost with the updated version
+
+- name: Remove a previously leaked mattermost-displaced folder
+  file:
+    path: /opt/mattermost-displaced
+    state: absent
+
+- name: Remove a previously leaked mattermost-updated folder
+  file:
+    path: /opt/mattermost-updated
+    state: absent
+
+- name: Create the displaced folder
+  file:
+    path: /opt/mattermost-displaced
+    state: directory
+
+- set_fact:
+    mattermost_archive_name: mattermost-team-{{ mattermost_version }}
+  when: not mattermost_enterprise
+
+- set_fact:
+    mattermost_archive_name: mattermost-{{ mattermost_version }}
+  when: mattermost_enterprise
+
+- name: 'Download binary from https://releases.mattermost.com'
+  get_url:
+    url: 'https://releases.mattermost.com/{{ mattermost_version }}/{{ mattermost_archive_name }}-linux-amd64.tar.gz'
+    dest: "{{ global_cache_dir | mandatory }}/"
+  become: false
+  delegate_to: localhost
+
+- name: Unpack Mattermost archive
+  unarchive:
+    src: "{{ global_cache_dir }}/{{ mattermost_archive_name }}-linux-amd64.tar.gz"
+    dest: /opt/mattermost-displaced/
+  args:
+
+- name: Create version file
+  copy:
+    content: "{{ mattermost_version }}"
+    dest: /opt/mattermost-displaced/mattermost/version
+    force: yes
+    owner: "{{ mattermost_user }}"
+    mode: 0644
+
+- name: Make sure the mattermost folder exists
+  file:
+    path: /opt/mattermost
+    state: directory
+
+- name: Create folders to synchronize
+  file:
+    path: /opt/{{ item[0] }}/{{ item[1] }}
+    state: directory
+    recurse: yes
+  with_nested:
+    - - mattermost
+      - mattermost-displaced/mattermost
+    - '{{ mattermost_preserve_on_update }}'
+
+# We stop the service before synchronizing such that no data is changed after synchronization
+- name: Stop mattermost service
+  service:
+    name: mattermost
+    enabled: yes
+    state: stopped
+
+- name: Synchronize the preserved folders
+  command: rsync -aI /opt/mattermost/{{ item }}/ /opt/mattermost-displaced/mattermost/{{ item }}
+  with_items: '{{ mattermost_preserve_on_update }}'
+
+- name: Indicate that the update finished successfully
+  command: mv /opt/mattermost-displaced /opt/mattermost-updated


### PR DESCRIPTION
Previously, mattermost was never updated after its initial installation.
See #7.
    
Now we check the installed version and update mattermost if it doesn't
equal the configured version.
    
In https://docs.mattermost.com/administration/upgrade.html it's suggested
to keep certain folders when updating, so we keep those if they exist.

Closes #7.