### PR TITLE
Update version by changing a symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ This role sets up and configures a Mattermost instance.
 
 It needs an apt based system like Ubuntu. Also the [stuvusIT.nginx](https://github.com/stuvusIT/nginx) and [stuvusIT.postgresql](https://github.com/stuvusIT/postgresql) roles are required.
 
+## Updating
+
+This role can not only install Mattermost, but also update it to a new version.
+To do so, just edit the role variable `mattermost_version` and run the role.
+Hereby it doesn't matter if the new version is higher or lower than the previous version.
+
 ## Role Variables
 
 | Name                              | Required                 | Default      | Description                                                                                                                                                                                            |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,11 +11,6 @@ mattermost_enterprise: false
 mattermost_teams: []
 mattermost_channels: []
 mattermost_admins: []
-mattermost_preserve_on_update:
-  - config
-  - logs
-  - bin/plugins
-  - bin/data
 # MATTERMOST config.json SETTINGS
 
 mattermost_Service_SiteURL: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,11 @@ mattermost_enterprise: false
 mattermost_teams: []
 mattermost_channels: []
 mattermost_admins: []
+mattermost_preserve_on_update:
+  - config
+  - logs
+  - bin/plugins
+  - bin/data
 # MATTERMOST config.json SETTINGS
 
 mattermost_Service_SiteURL: ""

--- a/tasks/collect-garbage.yml
+++ b/tasks/collect-garbage.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Find old mattermost versions
+  find:
+    paths: /opt/mattermost-versions
+    file_type: directory
+    excludes: '{{ mattermost_version }}'
+    recurse: no
+  register: mattermost_old_versions
+
+- name: Garbage collect old mattermost versions
+  file:
+    path: '{{ item.path }}'
+    state: absent
+  with_items: '{{ mattermost_old_versions.files }}'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,8 +3,6 @@
   copy:
     src: "{{ inventory_hostname }}/mattermost_licence"
     dest: "{{ mattermost_Service_LicenseFileLocation }}"
-    owner: "{{ mattermost_user }}"
-    group: "{{ mattermost_user }}"
     mode: 0600       
   when: mattermost_enterprise
 
@@ -12,35 +10,8 @@
   template:
     src: mattermost-config.json.j2
     dest: /opt/mattermost/config/config.json
-    owner: "{{ mattermost_user }}"
-    group: "{{ mattermost_user }}"
     mode: 0644
 
-- name: Change Mattermost directory permissions
-  file:
-    path: /opt/mattermost
-    state: directory
-    owner: "{{ mattermost_user }}"
-    group: "{{ mattermost_user }}"
-    recurse: yes
-
-- name: Place Mattermost licence file
-  copy:
-    src: "{{ inventory_hostname }}/mattermost_licence"
-    dest: "{{ mattermost_Service_LicenseFileLocation }}"
-    owner: "{{ mattermost_user }}"
-    group: "{{ mattermost_user }}"
-    mode: 0600       
-  when: mattermost_enterprise
-
-- name: Apply Mattermost config.json template
-  template:
-    src: mattermost-config.json.j2
-    dest: /opt/mattermost/config/config.json
-    owner: "{{ mattermost_user }}"
-    group: "{{ mattermost_user }}"
-    mode: 0644
-  
 - name: Change Mattermost directory permissions
   file:
     path: /opt/mattermost

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,11 @@
 ---
+
+- name: Create user to run Mattermost service
+  user:
+    name: "{{ mattermost_user }}"
+    system: yes
+    createhome: no
+
 - name: Place Mattermost licence file
   copy:
     src: "{{ inventory_hostname }}/mattermost_licence"

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -1,0 +1,33 @@
+---
+
+- block:
+
+  - name: Create folders to synchronize
+    file:
+      path: /opt/mattermost-versions/{{ mattermost_version }}/{{ item }}
+      state: directory
+      recurse: yes
+    with_items: '{{ mattermost_preserve_on_update }}'
+
+  # We stop the service before synchronizing such that no data is changed after synchronization
+  - name: Stop mattermost service
+    service:
+      name: mattermost
+      enabled: yes
+      state: stopped
+
+  - name: Synchronize the preserved folders
+    command: rsync -aI /opt/mattermost/{{ item }}/ /opt/mattermost-versions/{{ mattermost_version }}/{{ item }}
+    with_items: '{{ mattermost_preserve_on_update }}'
+
+  when: mattermost_previous_version is defined
+
+- name: Set the symlink to the installed mattermost version
+  file:
+    src: /opt/mattermost-versions/{{ mattermost_version }}
+    dest: /tmp/mattermost-symlink
+    state: link
+
+# mv is atomic and we want the activation of the new version to be atomic
+- name: Move the symlink into its place
+  command: mv -Tf /tmp/mattermost-symlink /opt/mattermost

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,46 +1,24 @@
 ---
-- name: 'Download binary from https://releases.mattermost.com'
-  get_url: 
-    url: 'https://releases.mattermost.com/{{ mattermost_version }}/mattermost-team-{{ mattermost_version }}-linux-amd64.tar.gz'
-    dest: "{{ global_cache_dir | mandatory }}/"
-  when: not mattermost_enterprise
-  become: false
-  delegate_to: localhost
 
-- name: 'Download enterprise version binary from https://releases.mattermost.com'
-  get_url: 
-    url: 'https://releases.mattermost.com/{{ mattermost_version }}/mattermost-{{ mattermost_version }}-linux-amd64.tar.gz'
-    dest: "{{ global_cache_dir | mandatory }}/"
-  when: mattermost_enterprise
-  become: false
-  delegate_to: localhost
+- name: Check if the desired mattermost version exists
+  stat:
+    path: /opt/mattermost-versions/{{ mattermost_version }}
+  register: mattermost_previous_stat
 
-- name: Unpack Mattermost archive
-  unarchive: 
-    src: "{{ global_cache_dir }}/mattermost-team-{{ mattermost_version }}-linux-amd64.tar.gz"
-    dest: /opt/
-  args:
-    creates: /opt/mattermost/bin/platform
-  when: not mattermost_enterprise
+- import_tasks: update.yml
+  when: not mattermost_previous_stat.stat.exists
 
-- name: Unpack Mattermost enterprise archive
-  unarchive: 
-    src: "{{ global_cache_dir }}/mattermost-{{ mattermost_version }}-linux-amd64.tar.gz"
-    dest: /opt/
-  args:
-    creates: /opt/mattermost/bin/platform
-  when: mattermost_enterprise
+- name: Check if any version is deployed
+  stat:
+    path: /opt/mattermost
+  register: mattermost_symlink_stat
 
-- name: Create user to run Mattermost service
-  user: 
-    name: "{{ mattermost_user }}"
-    system: yes
-    createhome: no 
+- name: Get the previous mattermost version
+  set_fact:
+    mattermost_previous_version: '{{ mattermost_symlink_stat.stat.lnk_target | basename }}'
+  when: mattermost_symlink_stat.stat.lnk_target is defined
 
-- name: Create version file
-  copy:
-    content: "{{ mattermost_version }}"
-    dest: /opt/mattermost/version
-    force: yes
-    owner: "{{ mattermost_user }}"
-    mode: 0644
+- import_tasks: deploy.yml
+  when: mattermost_previous_version is not defined or mattermost_previous_version != mattermost_version
+
+- import_tasks: collect-garbage.yml

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -36,3 +36,11 @@
     name: "{{ mattermost_user }}"
     system: yes
     createhome: no 
+
+- name: Create version file
+  copy:
+    content: "{{ mattermost_version }}"
+    dest: /opt/mattermost/version
+    force: yes
+    owner: "{{ mattermost_user }}"
+    mode: 0644

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -1,0 +1,31 @@
+---
+# Creates a folder /opt/mattermost/{{ mattermost_version }} with the desired version
+
+- set_fact:
+    mattermost_archive_name: mattermost-team-{{ mattermost_version }}
+  when: not mattermost_enterprise
+
+- set_fact:
+    mattermost_archive_name: mattermost-{{ mattermost_version }}
+  when: mattermost_enterprise
+
+- name: 'Download binary from https://releases.mattermost.com'
+  get_url:
+    url: 'https://releases.mattermost.com/{{ mattermost_version }}/{{ mattermost_archive_name }}-linux-amd64.tar.gz'
+    dest: "{{ global_cache_dir | mandatory }}/"
+  become: false
+  delegate_to: localhost
+
+- name: Unpack Mattermost archive
+  unarchive:
+    src: "{{ global_cache_dir }}/{{ mattermost_archive_name }}-linux-amd64.tar.gz"
+    dest: /tmp
+  args:
+
+- name: Make sure the mattermost-versions folder exists
+  file:
+    path: /opt/mattermost-versions
+    state: directory
+
+- name: Move updated mattermost version into its place
+  command: mv /tmp/mattermost /opt/mattermost-versions/{{ mattermost_version }}

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -9,18 +9,17 @@
     mattermost_archive_name: mattermost-{{ mattermost_version }}
   when: mattermost_enterprise
 
-- name: 'Download binary from https://releases.mattermost.com'
+- name: Download binary from https://releases.mattermost.com
   get_url:
-    url: 'https://releases.mattermost.com/{{ mattermost_version }}/{{ mattermost_archive_name }}-linux-amd64.tar.gz'
+    url: https://releases.mattermost.com/{{ mattermost_version }}/{{ mattermost_archive_name }}-linux-amd64.tar.gz
     dest: "{{ global_cache_dir | mandatory }}/"
   become: false
   delegate_to: localhost
 
 - name: Unpack Mattermost archive
   unarchive:
-    src: "{{ global_cache_dir }}/{{ mattermost_archive_name }}-linux-amd64.tar.gz"
+    src: '{{ global_cache_dir }}/{{ mattermost_archive_name }}-linux-amd64.tar.gz'
     dest: /tmp
-  args:
 
 - name: Make sure the mattermost-versions folder exists
   file:

--- a/templates/systemd.j2
+++ b/templates/systemd.j2
@@ -4,9 +4,9 @@ After=syslog.target network.target postgresql.service
 
 [Service]
 Type=simple
-WorkingDirectory=/opt/mattermost/bin
+WorkingDirectory=/opt/mattermost/{{ mattermost_version }}/bin
 User={{ mattermost_user }}
-ExecStart=/opt/mattermost/bin/platform
+ExecStart=/opt/mattermost/{{ mattermost_version }}/bin/platform
 PIDFile=/var/spool/mattermost/pid/master.pid
 
 [Install]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,7 @@
+---
+
+mattermost_preserve_on_update:
+  - config
+  - logs
+  - bin/plugins
+  - bin/data


### PR DESCRIPTION
NOTE: This PR is exclusively alternative to #9.

Previously, mattermost was never updated after its initial installation. See #7.

Now we install mattermost in a separate folder per version. We check the if the configured version is installed and if not, install it (*). The newly installed version is then deployed by simply changing the symlink at `/opt/mattermost`.

(*) In https://docs.mattermost.com/administration/upgrade.html it's suggested to keep certain folders when updating, so we sync those from the current version to the newly installed version.

**Consider that, although it doesn't seem like it, this way of updating mattermost is less complex than the way in #9** (compare +116 -63 to +122 -61 changes).

Closes #7 
Closes #9 